### PR TITLE
Open-ended IDE version for wider availability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.duartbreedt.movementprogressbars'
-version '1.0.3'
+version '1.0.4'
 
 repositories {
     mavenCentral()
@@ -20,7 +20,10 @@ intellij {
 }
 
 patchPluginXml {
+    sinceBuild = '201'
+    untilBuild = ''
     changeNotes = """
+      <em>1.0.4 Open-ended IDE version for wider availability</em><br>
       <em>1.0.3 Ported the plugin to older IDE versions</em><br>
       <em>1.0.2 Updated the plugin icon</em><br>
       <em>1.0.1 Added more flags + plugin icon</em><br>


### PR DESCRIPTION
Since there is no technical reason to restrict this plugin to Version 2020.1 I removed the untilBuild constraint so that newer versions of the IDE no longer refuse to install the plugin, and so that it is still visible in the marketplace for newer versions. I tested this on PHPStorm 2022.1 without any problems.